### PR TITLE
Add sqlite-dev dependency to prevent sqlite3 gem install error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --update --virtual \
   readline \
   build-base \
   postgresql-dev \
+  sqlite-dev \
   libc-dev \
   linux-headers \
   readline-dev \


### PR DESCRIPTION
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
checking for sqlite3.h... no
sqlite3.h is missing